### PR TITLE
fix: updates .gitignore file and adds bin/console folder to php example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ package-lock.json
 ### .NET ###
 **.sln
 **.http
-bin/
+**/dotnet/**/bin/
 obj/
 .fake
 

--- a/server/php/bin/console
+++ b/server/php/bin/console
@@ -1,0 +1,21 @@
+#!/usr/bin/env php
+<?php
+
+use App\Kernel;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+
+if (!is_dir(dirname(__DIR__).'/vendor')) {
+    throw new LogicException('Dependencies are missing. Try running "composer install".');
+}
+
+if (!is_file(dirname(__DIR__).'/vendor/autoload_runtime.php')) {
+    throw new LogicException('Symfony Runtime is missing. Try running "composer require symfony/runtime".');
+}
+
+require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
+
+return function (array $context) {
+    $kernel = new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
+
+    return new Application($kernel);
+};

--- a/server/php/config/packages/nelmio_cors.yaml
+++ b/server/php/config/packages/nelmio_cors.yaml
@@ -1,7 +1,7 @@
 nelmio_cors:
     defaults:
         origin_regex: true
-        allow_origin: ['%env(CORS_ALLOW_ORIGIN)%']
+        allow_origin: ['*']
         allow_methods: ['GET', 'OPTIONS', 'POST', 'PUT', 'PATCH', 'DELETE']
         allow_headers: ['Content-Type', 'Authorization']
         expose_headers: ['Link']


### PR DESCRIPTION
- Adds `bin/console` folder to php example
- Allows * origins to prevent CORS from blocking requests